### PR TITLE
Prevent TypeError from `null` TextBody when pulling templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postmark-cli",
-  "version": "1.6.15",
+  "version": "1.6.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postmark-cli",
-      "version": "1.6.15",
+      "version": "1.6.16",
       "license": "MIT",
       "dependencies": {
         "@types/traverse": "^0.6.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postmark-cli",
-  "version": "1.6.15",
+  "version": "1.6.16",
   "description": "A CLI tool for managing templates, sending emails, and fetching servers on Postmark.",
   "main": "./dist/index.js",
   "dependencies": {

--- a/src/commands/templates/pull.ts
+++ b/src/commands/templates/pull.ts
@@ -199,7 +199,7 @@ const saveTemplate = (outputDir: string, template: Template, client: any) => {
   }
 
   // Save Text version
-  if (template.TextBody !== '') {
+  if (template.TextBody !== null && template.TextBody !== '') {
     outputFileSync(join(path, 'content.txt'), template.TextBody)
   }
 


### PR DESCRIPTION
Hey @tomek-ac,

On some templates, [Postmark's API](https://postmarkapp.com/developer/api/templates-api#get-template) returns a `null` value on the `TextBody` if there's no content. It should return an empty string, so I'll report this to the backend team. This occasionally causes a type error when running `postmark templates pull`, so I've updated the conditional here to check this before saving the text version. 

Related: #48 