### PR TITLE
feat: add support for `templates delete` command

### DIFF
--- a/src/commands/templates/delete.ts
+++ b/src/commands/templates/delete.ts
@@ -1,0 +1,143 @@
+// TODO
+// - allow deleting template by id
+// - allow deleting a list of ids (template1, template2, template3, etc.)
+// - allow deleting all templates without confirmation (-f flag useful for CI)
+// - allow specifying template type to delete
+
+import { confirm } from "@inquirer/prompts";
+import ora from "ora";
+import { ServerClient } from "postmark";
+
+import {
+  fatalError,
+  log,
+  logError,
+  pluralize,
+  validateToken,
+} from "../../utils";
+import { template } from "lodash";
+
+interface TemplateDeleteArguments {
+  serverToken: string;
+  requestHost: string;
+}
+
+export interface TemplateListOptions {
+  sourceServer: string;
+  requestHost: string;
+}
+
+export async function handler(args: TemplateDeleteArguments): Promise<void> {
+  const serverToken = await validateToken(args.serverToken);
+  const requestHost = args.requestHost;
+  deletePrompt(serverToken, requestHost);
+}
+
+/**
+ * Begin deleting the templates
+ */
+async function _delete(
+  serverToken: string,
+  args: TemplateDeleteArguments
+): Promise<void> {
+  const { requestHost } = args;
+  return fetchTemplateList({
+    sourceServer: serverToken,
+    requestHost: requestHost,
+  });
+}
+
+/**
+ * Ask user to confirm delete
+ */
+
+async function deletePrompt(
+  serverToken: string,
+  requestHost: string
+): Promise<void> {
+  const answer = await confirm({
+    default: false,
+    message: `Delete ALL templates? Are you sure?`,
+  });
+
+  if (answer) {
+    return fetchTemplateList({
+      sourceServer: serverToken,
+      requestHost: requestHost,
+    });
+  }
+}
+
+/**
+ * Fetch template list from PM
+ */
+
+async function fetchTemplateList(options: TemplateListOptions) {
+  const { sourceServer, requestHost } = options;
+
+  // keep track of templates deleted
+  let totalDeleted = 0;
+
+  const spinner = ora("Deleting templates from Postmark...");
+  spinner.start();
+
+  const client = new ServerClient(sourceServer);
+
+  if (requestHost !== undefined && requestHost !== "") {
+    client.setClientOptions({ requestHost });
+  }
+
+  try {
+    const templates = await client.getTemplates({ count: 300 });
+
+    const totalTemplates = templates.Templates.filter(
+      (template) => template.TemplateType !== "Layout"
+    ).length;
+
+    if (!templates.TotalCount) {
+      spinner.stop();
+      return fatalError("There are no templates on this server.");
+    } else {
+      spinner.text = `Deleting ${totalTemplates} templates from Postmark...`;
+
+      for (const template of templates.Templates) {
+        spinner.text = `Deleting template: ${template.Alias || template.Name}`;
+
+        // TemplateId is always defined so use it instead of Alias
+        const id = template.TemplateId;
+
+        // NOTE we do not want to delete "Layouts"
+        if (template.TemplateType !== "Layout") {
+          try {
+            const response = await client.deleteTemplate(id);
+
+            spinner.text = `Template: ${
+              template.Alias || template.Name
+            } removed.`;
+
+            totalDeleted++;
+          } catch (e) {
+            spinner.stop();
+            logError(e);
+          }
+        }
+      }
+
+      // Show feedback when finished deleting templates
+      if (totalDeleted === totalTemplates) {
+        spinner.stop();
+        log(
+          `All finished! ${totalDeleted} ${pluralize(
+            totalDeleted,
+            "template has",
+            "templates have"
+          )} been deleted.`,
+          { color: "green" }
+        );
+      }
+    }
+  } catch (err) {
+    spinner.stop();
+    return fatalError(err);
+  }
+}

--- a/src/commands/templates/delete.ts
+++ b/src/commands/templates/delete.ts
@@ -15,7 +15,6 @@ import {
   pluralize,
   validateToken,
 } from "../../utils";
-import { template } from "lodash";
 
 interface TemplateDeleteArguments {
   serverToken: string;
@@ -34,20 +33,6 @@ export async function handler(args: TemplateDeleteArguments): Promise<void> {
 }
 
 /**
- * Begin deleting the templates
- */
-async function _delete(
-  serverToken: string,
-  args: TemplateDeleteArguments
-): Promise<void> {
-  const { requestHost } = args;
-  return fetchTemplateList({
-    sourceServer: serverToken,
-    requestHost: requestHost,
-  });
-}
-
-/**
  * Ask user to confirm delete
  */
 
@@ -61,7 +46,7 @@ async function deletePrompt(
   });
 
   if (answer) {
-    return fetchTemplateList({
+    return deleteTemplates({
       sourceServer: serverToken,
       requestHost: requestHost,
     });
@@ -69,10 +54,10 @@ async function deletePrompt(
 }
 
 /**
- * Fetch template list from PM
+ * Delete templates from PM
  */
 
-async function fetchTemplateList(options: TemplateListOptions) {
+async function deleteTemplates(options: TemplateListOptions) {
   const { sourceServer, requestHost } = options;
 
   // keep track of templates deleted
@@ -109,7 +94,7 @@ async function fetchTemplateList(options: TemplateListOptions) {
         // NOTE we do not want to delete "Layouts"
         if (template.TemplateType !== "Layout") {
           try {
-            const response = await client.deleteTemplate(id);
+            await client.deleteTemplate(id);
 
             spinner.text = `Template: ${
               template.Alias || template.Name


### PR DESCRIPTION
This is an implementation of a `postmark templates delete` command, allowing users to delete by id or alias (one or multiple) or all templates from their server.

```
$ postmark templates delete

> postmark templates delete
? Please enter your server token ••••••••••••••••••••••••••••••••••••
? Choose how you want to delete templates: Delete templates by id
? Enter template id(s) - separated by commas if multiple: 33336536, 33336535, 33336549
All finished! 3 templates have been deleted.
```

```
> postmark templates delete
? Please enter your server token ••••••••••••••••••••••••••••••••••••
? Choose how you want to delete templates: Delete all templates
? Which template type do you want to delete? Templates
? Delete ALL templates? Are you sure? yes
? Enter "delete all templates" to confirm: delete all templates
All finished! 80 templates have been deleted.
```

```
> postmark templates delete
? Please enter your server token ••••••••••••••••••••••••••••••••••••
? Choose how you want to delete templates: Delete all templates
? Which template type do you want to delete? Layouts
? Delete ALL templates? Are you sure? yes
? Enter "delete all templates" to confirm: delete all templates
All finished! 4 templates have been deleted.
```